### PR TITLE
Update esperanto to 0.7.x and fix failing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Attamusc/gulp-esperanto",
   "dependencies": {
-    "esperanto": "^0.6.16",
+    "esperanto": "^0.7.3",
     "gulp-util": "^3.0.2",
     "object-assign": "^2.0.0",
     "through2": "^0.6.3",

--- a/test.js
+++ b/test.js
@@ -32,7 +32,7 @@ it('should generate source maps', function (cb) {
     .pipe(write);
 
   write.on('data', function (file) {
-    assert.deepEqual(file.sourceMap.sources, ['../../fixture.js']);
+    assert.deepEqual(file.sourceMap.sources, ['fixture.js']);
     var contents = file.contents.toString();
     assert(/function/.test(contents));
     assert(/sourceMappingURL/.test(contents));


### PR DESCRIPTION
- Sourcemap test was broken since https://github.com/esperantojs/esperanto/commit/059865f869048989a8e764f3970f3219c505b43c, 0.6.29
- Update esperanto to current latest, 0.7.3
